### PR TITLE
Correct odd menu spacing

### DIFF
--- a/theme/zeta.css
+++ b/theme/zeta.css
@@ -228,7 +228,6 @@ color:#688b6a;
 display:block;
 padding:4px .25em;
 position:relative;
-width:9em;
 }
 
 .drop_menu a:hover {

--- a/theme/zeta.css
+++ b/theme/zeta.css
@@ -228,6 +228,7 @@ color:#688b6a;
 display:block;
 padding:4px .25em;
 position:relative;
+padding-right:14px;
 }
 
 .drop_menu a:hover {


### PR DESCRIPTION
Removing this width corrects odd menu spacing on both Firefox desktop and mobile.

Screenshots:
Before:
![beforecss](https://user-images.githubusercontent.com/15039983/47758555-e4a96a00-dc81-11e8-8871-cd1c21df1280.png)
After: 
![aftercss](https://user-images.githubusercontent.com/15039983/47758566-ebd07800-dc81-11e8-8c4c-62110de0f335.png)
